### PR TITLE
fix(deps): widen version range on google-cloud-logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version = "1.1.2"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
-    "google-cloud-logging>=1.14.0, <2.5",
+    "google-cloud-logging>=1.14.0, <3.0.0dev",
     "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
     "proto-plus >= 1.4.0",
     "packaging >= 14.3",


### PR DESCRIPTION
In response to https://github.com/GoogleCloudPlatform/getting-started-python/pull/361 and https://github.com/GoogleCloudPlatform/getting-started-python/issues/357.

Given the libraries adhere to semantic versioning it should be fine to use `google-cloud-logging<3.0.0dev`.