### PR TITLE
fix: exception when grpc is disabled

### DIFF
--- a/google/cloud/error_reporting/_logging.py
+++ b/google/cloud/error_reporting/_logging.py
@@ -70,8 +70,8 @@ class _ErrorReportingLoggingAPI(object):
         client_options=None,
     ):
         self.logging_client = google.cloud.logging.Client(
-            project,
-            credentials,
+            project=project,
+            credentials=credentials,
             _http=_http,
             client_info=client_info,
             client_options=client_options,

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -114,7 +114,6 @@ def _get_error_count(class_name, client):
 
 
 class TestErrorReporting(unittest.TestCase):
-
     def test_report_exception(self):
         # Get a class name unique to this test case.
         class_name = "RuntimeError" + unique_resource_id("_")
@@ -132,7 +131,7 @@ class TestErrorReporting(unittest.TestCase):
         self.assertEqual(error_count, 1)
 
     def test_report_exception_no_grpc(self):
-        with mock.patch.dict('os.environ',
-                {'GOOGLE_CLOUD_DISABLE_GRPC': 'true'}, clear=True):
+        with mock.patch.dict(
+            "os.environ", {"GOOGLE_CLOUD_DISABLE_GRPC": "true"}, clear=True
+        ):
             self.test_report_exception()
-

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -15,6 +15,8 @@
 import functools
 import operator
 import unittest
+import os
+import mock
 
 from google.cloud import error_reporting
 import google.cloud.errorreporting_v1beta1
@@ -112,6 +114,7 @@ def _get_error_count(class_name, client):
 
 
 class TestErrorReporting(unittest.TestCase):
+
     def test_report_exception(self):
         # Get a class name unique to this test case.
         class_name = "RuntimeError" + unique_resource_id("_")
@@ -127,3 +130,9 @@ class TestErrorReporting(unittest.TestCase):
 
         error_count = wrapped_get_count(class_name, Config.CLIENT)
         self.assertEqual(error_count, 1)
+
+    def test_report_exception_no_grpc(self):
+        with mock.patch.dict('os.environ',
+                {'GOOGLE_CLOUD_DISABLE_GRPC': 'true'}, clear=True):
+            self.test_report_exception()
+

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -15,7 +15,6 @@
 import functools
 import operator
 import unittest
-import os
 import mock
 
 from google.cloud import error_reporting

--- a/tests/unit/test__logging.py
+++ b/tests/unit/test__logging.py
@@ -40,7 +40,11 @@ class Test_ErrorReportingLoggingAPI(unittest.TestCase):
 
         self.assertIs(logging_api.logging_client, mocked_cls.return_value)
         mocked_cls.assert_called_once_with(
-            self.PROJECT, credentials, _http=None, client_info=None, client_options=None
+            project=self.PROJECT,
+            credentials=credentials,
+            _http=None,
+            client_info=None,
+            client_options=None,
         )
 
     @mock.patch("google.cloud.logging.Client")
@@ -60,8 +64,8 @@ class Test_ErrorReportingLoggingAPI(unittest.TestCase):
 
         self.assertIs(logging_api.logging_client, mocked_cls.return_value)
         mocked_cls.assert_called_once_with(
-            self.PROJECT,
-            credentials,
+            project=self.PROJECT,
+            credentials=credentials,
             _http=http,
             client_info=client_info,
             client_options=client_options,


### PR DESCRIPTION
Fixes https://github.com/googleapis/python-error-reporting/issues/135

The library was crashing when grpc was disabled. Initializing logging client using keyword arguments instead of positional ones fixes this

I also added a test to prevent these issues in the future