### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "clouderrorreporting",
     "name_pretty": "Cloud Error Reporting",
     "product_documentation": "https://cloud.google.com/error-reporting",
-    "client_documentation": "https://googleapis.dev/python/clouderrorreporting/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/clouderrorreporting/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559780",
     "release_level": "beta",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.