### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "clouderrorreporting",
     "name_pretty": "Cloud Error Reporting",
     "product_documentation": "https://cloud.google.com/error-reporting",
-    "client_documentation": "https://googleapis.dev/python/clouderrorreporting/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/clouderrorreporting/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559780",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ to receive email and mobile alerts on new errors.
 - `Product Documentation`_
 
 .. _Error Reporting: https://cloud.google.com/error-reporting/
-.. _Client Library Documentation: https://googleapis.dev/python/clouderrorreporting/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/clouderrorreporting/latest
 .. _Product Documentation: https://cloud.google.com/error-reporting/reference/
 .. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
    :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#beta-support


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.