### PR TITLE
fix(main): Update minimum requirements for google-cloud-logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ dependencies = [
     # NOTE: Maintainers, please do not require google-api-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
-    "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
+    "google-api-core[grpc] >= 1.28.0, <4.0.0dev",
     "proto-plus >= 1.4.0",
 ]
 extras = {}


### PR DESCRIPTION
It exist a conflict when installing google-cloud-logging because the latest version of google-cloud-logging is [3.0.0](https://github.com/googleapis/python-logging/releases/tag/v3.0.0).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-error-reporting/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
