### PR TITLE
chore: update blunderbuss asignments

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,4 +1,4 @@
 assign_issues:
-  - Daniel-Sanche
+  - googleapis/api-logging-reviewers
 assign_prs:
-  - Daniel-Sanche
+  - googleapis/api-logging-reviewers


### PR DESCRIPTION
update blunderbuss to assign PRs to `googleapis/api-logging-reviewers`, rather than directly to me