### PR TITLE
feat: use native namespaces instead of pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,13 +54,9 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 
 packages = [
     package
-    for package in setuptools.PEP420PackageFinder.find()
+    for package in setuptools.find_namespace_packages()
     if package.startswith("google")
 ]
-
-namespaces = ["google"]
-if "google.cloud" in packages:
-    namespaces.append("google.cloud")
 
 setuptools.setup(
     name=name,
@@ -88,7 +84,6 @@ setuptools.setup(
     platforms="Posix; MacOS X; Windows",
     packages=packages,
     python_requires=">=3.7",
-    namespace_packages=namespaces,
     install_requires=dependencies,
     include_package_data=True,
     zip_safe=False,

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -47,7 +47,7 @@ def test_namespace_package_compat(tmp_path):
         "google.otherpkg",
         "google.cloud.otherpkg",
         "google.cloud.error_reporting",
-        "google.cloud.errorreporting_v1beta1"
+        "google.cloud.errorreporting_v1beta1",
     ]:
         cmd = [sys.executable, "-c", f"import {pkg}"]
         subprocess.check_output(cmd, env=env)

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -19,7 +19,7 @@ import sys
 
 def test_namespace_package_compat(tmp_path):
     # The ``google`` namespace package should not be masked
-    # by the presence of ``google-cloud-logging``.
+    # by the presence of ``google-cloud-error-reporting``.
 
     google = tmp_path / "google"
     google.mkdir()
@@ -30,7 +30,7 @@ def test_namespace_package_compat(tmp_path):
     google_otherpkg.joinpath("__init__.py").write_text("")
 
     # The ``google.cloud`` namespace package should not be masked
-    # by the presence of ``google-cloud-logging``.
+    # by the presence of ``google-cloud-error-reporting``.
     google_cloud = tmp_path / "google" / "cloud"
     google_cloud.mkdir()
     google_cloud.joinpath("othermod.py").write_text("")

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+
+
+def test_namespace_package_compat(tmp_path):
+    # The ``google`` namespace package should not be masked
+    # by the presence of ``google-cloud-logging``.
+
+    google = tmp_path / "google"
+    google.mkdir()
+    google.joinpath("othermod.py").write_text("")
+
+    google_otherpkg = tmp_path / "google" / "otherpkg"
+    google_otherpkg.mkdir()
+    google_otherpkg.joinpath("__init__.py").write_text("")
+
+    # The ``google.cloud`` namespace package should not be masked
+    # by the presence of ``google-cloud-logging``.
+    google_cloud = tmp_path / "google" / "cloud"
+    google_cloud.mkdir()
+    google_cloud.joinpath("othermod.py").write_text("")
+
+    google_cloud_otherpkg = tmp_path / "google" / "cloud" / "otherpkg"
+    google_cloud_otherpkg.mkdir()
+    google_cloud_otherpkg.joinpath("__init__.py").write_text("")
+
+    env = dict(os.environ, PYTHONPATH=str(tmp_path))
+
+    for pkg in [
+        "google.othermod",
+        "google.cloud.othermod",
+        "google.otherpkg",
+        "google.cloud.otherpkg",
+        "google.cloud.error_reporting",
+        "google.cloud.errorreporting_v1beta1"
+    ]:
+        cmd = [sys.executable, "-c", f"import {pkg}"]
+        subprocess.check_output(cmd, env=env)
+
+    for module in ["google.othermod", "google.cloud.othermod"]:
+        cmd = [sys.executable, "-m", module]
+        subprocess.check_output(cmd, env=env)


### PR DESCRIPTION
Native namespace package support for python-error-reporting, used googleapis/python-logging#812 as a reference.
