### PR TITLE
fix: require proto-plus >= 1.25.0 for Python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ dependencies = [
     "google-api-core[grpc] >= 1.34.0, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
     "proto-plus >= 1.22.0, <2.0.0",
     "proto-plus >= 1.22.2, <2.0.0; python_version>='3.11'",
+    "proto-plus >= 1.25.0, <2.0.0dev; python_version>='3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 url = "https://github.com/googleapis/python-error-reporting"


### PR DESCRIPTION
Fixes #531 