### PR TITLE
chore: librarian release pull request: 20251216T123125Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
 libraries:
   - id: google-cloud-error-reporting
-    version: 1.13.0
+    version: 1.14.0
     last_generated_commit: cf0434f4bd20618db60ddd16a1e7db2c0dfb9158
     apis:
       - path: google/devtools/clouderrorreporting/v1beta1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-error-reporting/#history
 
+## [1.14.0](https://github.com/googleapis/python-error-reporting/compare/v1.13.0...v1.14.0) (2025-12-16)
+
+
+### Features
+
+* support mTLS certificates when available (#717) ([7e99258b41ddef55b63c70c7e31afced4ab30103](https://github.com/googleapis/python-error-reporting/commit/7e99258b41ddef55b63c70c7e31afced4ab30103))
+
 ## [1.13.0](https://github.com/googleapis/python-error-reporting/compare/v1.12.0...v1.13.0) (2025-11-12)
 
 

--- a/google/cloud/error_reporting/gapic_version.py
+++ b/google/cloud/error_reporting/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.13.0"  # {x-release-please-version}
+__version__ = "1.14.0"  # {x-release-please-version}

--- a/google/cloud/errorreporting_v1beta1/gapic_version.py
+++ b/google/cloud/errorreporting_v1beta1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.13.0"  # {x-release-please-version}
+__version__ = "1.14.0"  # {x-release-please-version}

--- a/samples/generated_samples/snippet_metadata_google.devtools.clouderrorreporting.v1beta1.json
+++ b/samples/generated_samples/snippet_metadata_google.devtools.clouderrorreporting.v1beta1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-error-reporting",
-    "version": "1.13.0"
+    "version": "1.14.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
<details><summary>google-cloud-error-reporting: 1.14.0</summary>

## [1.14.0](https://github.com/googleapis/python-error-reporting/compare/v1.13.0...v1.14.0) (2025-12-16)

### Features

* support mTLS certificates when available (#717) ([7e99258b](https://github.com/googleapis/python-error-reporting/commit/7e99258b))

</details>